### PR TITLE
Correct Innacurate Benchmarks

### DIFF
--- a/benchmark_github_test.go
+++ b/benchmark_github_test.go
@@ -1,6 +1,7 @@
 package iris
 
 import (
+	"io"
 	"net/http"
 	"runtime"
 	"testing"
@@ -338,10 +339,8 @@ func calcMem(name string, load func()) {
 	println("   "+name+":", after-before, "Bytes")
 }
 
-//
-
 func irisHandleTestContexted(c *Context) {
-	///TODO: something
+	io.WriteString(c.ResponseWriter, c.Request.RequestURI)
 }
 
 func loadIris(routes []routeTest) http.Handler {


### PR DESCRIPTION
* iris handler was empty, but competitor benchmarks were printing the RequestURI as a response; now competitors are much closer!

#### With Cache Disabled
```go
BenchmarkLARS_GithubAll	   30000	     46975 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_GithubAll 	   30000	     49650 ns/op	       0 B/op	       0 allocs/op
BenchmarkIris_GithubAll	   30000	     43427 ns/op	       0 B/op	       0 allocs/op
```

#### With Cache Enabled
```go
BenchmarkLARS_GithubAll	   30000	     47059 ns/op	       0 B/op	       0 allocs/op
BenchmarkGin_GithubAll 	   30000	     49459 ns/op	       0 B/op	       0 allocs/op
BenchmarkIris_GithubAll	   50000	     29285 ns/op	       0 B/op	       0 allocs/op
```