### PR TITLE
Update README - make basic example start server with 'log.Fatal'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,16 @@ Iris is a very minimal but flexible go web framework  providing arobust set of f
 ```go
 package main
 
-import "github.com/kataras/iris"
+import (
+  "github.com/kataras/iris"
+  "log"
+)
 
 func main() {
 	iris.Get("/hello", func(c *iris.Context) {
 		c.HTML("<b> Hello </b>")
 	})
-	iris.Listen(":8080")
+	log.Fatal(iris.Listen(":8082"))
 }
 
 ```


### PR DESCRIPTION
- This gives a better indication of failure, especially in the case of a port conflict
(did not mean to change to 8082 here, but 8080 is a quite popular port these days).
- This is very important as I almost gave up on the framework as I thought it was broken.