### PR TITLE
Fixes bug with "nil" Interfaces Values

### DIFF
--- a/iris.go
+++ b/iris.go
@@ -663,7 +663,12 @@ func Lookups() []Route {
 
 // Lookup returns a registed route by its name
 func (s *Framework) Lookup(routeName string) Route {
-	return s.mux.lookup(routeName)
+	route := s.mux.lookup(routeName)
+	if nil == route {
+		return nil
+	}
+
+	return route
 }
 
 // Lookups returns all registed routes


### PR DESCRIPTION
Fixes a bug with "nil" Interfaces and "nil" Interfaces Values.

If you return directly from `s.mux.lookup(routeName)` this check will be false.

```
nil == iris.Lookup(route) //false
```

Since you need to explicit return nil if you have an interface return type:

http://devs.cloudimmunity.com/gotchas-and-common-mistakes-in-go-golang/index.html#nil_in_nil_in_vals