### PR TITLE
Update README.md - add JOSE middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ Third Party
 ------------
 these are third party features that are developped as extensions for IRIS.
 
-|Name | Description | Usage |
-|-----|-------------|-------|
-[JOSE middleware](https://github.com/Heirko/iris-contrib/tree/master/middleware/jose) | JOSE handling middleware | [example](https://godoc.org/github.com/Heirko/iris-contrib/middleware/jose#example-package) [book section](https://github.com/Heirko/iris-contrib/tree/master/middleware/jose)
+| Name        | Description           | Usage  |
+| ------------------|:---------------------:|-------:|
+| [JOSE middleware](https://github.com/Heirko/iris-contrib/tree/master/middleware/jose)      | JOSE handling middleware  |[example](https://godoc.org/github.com/Heirko/iris-contrib/middleware/jose#example-package), [GoDoc section](https://github.com/Heirko/iris-contrib/tree/master/middleware/jose)
 
 
 FAQ

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ these are third party features that are developped as extensions for IRIS.
 
 | Name        | Description           | Usage  |
 | ------------------|:---------------------:|-------:|
-| [JOSE middleware](https://github.com/Heirko/iris-contrib/tree/master/middleware/jose)      | JOSE handling middleware  |[example](https://godoc.org/github.com/Heirko/iris-contrib/middleware/jose#example-package), [GoDoc section](https://github.com/Heirko/iris-contrib/tree/master/middleware/jose)
+| [JOSE middleware](https://github.com/Heirko/iris-contrib/tree/master/middleware/jose)      | JOSE handling middleware  |[example](https://godoc.org/github.com/Heirko/iris-contrib/middleware/jose#example-package), [GoDoc section](https://godoc.org/github.com/Heirko/iris-contrib/middleware/jose)
 
 
 FAQ

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ Features
 | [OAuth,OAuth2 Plugin](https://github.com/iris-contrib/plugin/tree/master/oauth) |  User Authentication was never be easier, supports >27 providers |    [example](https://github.com/iris-contrib/examples/tree/master/plugin_oauth_oauth2), [book section](https://kataras.gitbooks.io/iris/content/plugin-oauth.html) |
 | [Iris control Plugin](https://github.com/iris-contrib/plugin/tree/master/iriscontrol) |   Basic (browser-based) control over your Iris station |    [example](https://github.com/iris-contrib/examples/blob/master/plugin_iriscontrol/main.go), [book section](https://kataras.gitbooks.io/iris/content/plugin-iriscontrol.html) |
 
+Third Party
+------------
+these are third party features that are developped as extensions for IRIS.
+
+|Name | Description | Usage |
+|-----|-------------|-------|
+[JOSE middleware](https://github.com/Heirko/iris-contrib/tree/master/middleware/jose) | JOSE handling middleware | [example](https://godoc.org/github.com/Heirko/iris-contrib/middleware/jose#example-package) [book section](https://github.com/Heirko/iris-contrib/tree/master/middleware/jose)
+
 
 FAQ
 ------------


### PR DESCRIPTION
We updated the file README.md with a third party section that holds a table for third party features. 
We added there a link to our JOSE middleware, developped for IRIS. 