### PR TITLE
The StaticWeb function leaves out the reqPath for the auto index path.

### DIFF
--- a/iris.go
+++ b/iris.go
@@ -1674,7 +1674,7 @@ func (api *muxAPI) StaticWeb(reqPath string, systemPath string, stripSlashes int
 	serveHandler := api.StaticHandler(systemPath, stripSlashes, false, !hasIndex, nil) // if not index.html exists then generate index.html which shows the list of files
 	indexHandler := func(ctx *Context) {
 		if len(ctx.Param("filepath")) < 2 && hasIndex {
-			ctx.Request.SetRequestURI("index.html")
+			ctx.Request.SetRequestURI(reqPath + "index.html")
 		}
 		ctx.Next()
 


### PR DESCRIPTION
Just a quick fix the adds the reqPath back to the index path.