### PR TITLE
ReadJSON fix

### DIFF
--- a/context.go
+++ b/context.go
@@ -377,11 +377,10 @@ func (ctx *Context) ReadJSON(jsonObject *interface{}) error {
 	//Go's JSON actually expects a pointer not just a object
 	//And why abuse strings.NewReader? Just let Unmarshal do it
 	data := ctx.GetRequestCtx().PostBody()
-	json.Unmarshal(data, &jsonObject)
-	err := decoder.Decode(jsonObject)
+	err := json.Unmarshal(data, &jsonObject)
 
 	//err != nil fix by @shiena
-	if err != nil && err != io.EOF {
+	if err != nil {
 		return errReadBody.Format("JSON", err.Error())
 	}
 

--- a/context.go
+++ b/context.go
@@ -1,4 +1,5 @@
 /*
+/*
 Context.go  Implements: ./context/context.go
 */
 
@@ -372,10 +373,11 @@ func (ctx *Context) Subdomain() (subdomain string) {
 }
 
 // ReadJSON reads JSON from request's body
-func (ctx *Context) ReadJSON(jsonObject interface{}) error {
-	data := ctx.RequestCtx.Request.Body()
-
-	decoder := json.NewDecoder(strings.NewReader(string(data)))
+func (ctx *Context) ReadJSON(jsonObject *interface{}) error {
+	//Go's JSON actually expects a pointer not just a object
+	//And why abuse strings.NewReader? Just let Unmarshal do it
+	data := ctx.GetRequestCtx().PostBody()
+	json.Unmarshal(data, &jsonObject)
 	err := decoder.Decode(jsonObject)
 
 	//err != nil fix by @shiena


### PR DESCRIPTION
Go's encoding/json expects the interface{} to be a pointer..

Also, why are you abusing NewReader, leave it to Unmarshal to do it.