### PR TITLE
typo(readme): fix email address typo in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ func details(ctx *iris.Context){
 name | value
 :--- | :---
 name | Gerasimos Maropoulos
-email | kataras2006@homail.com
+email | kataras2006@hotmail.com
 
 
 ```go


### PR DESCRIPTION
It's not important at all. Just saw it and decided to fix it. 😁