### PR TITLE
fix: template Render error

### DIFF
--- a/_examples/intermediate/e-mail/main.go
+++ b/_examples/intermediate/e-mail/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"html/template"
 
 	"github.com/kataras/go-mailer"
 	"gopkg.in/kataras/iris.v6"
 	"gopkg.in/kataras/iris.v6/adaptors/httprouter"
 )
+var t = template.Must(template.ParseFiles(filepath.Join("templates", "mail_body.html")))
 
 func main() {
 
@@ -58,11 +60,13 @@ func main() {
 		// the rest of the parameters are the same and the behavior is the same as ctx.Render,
 		// except the 'where to render'
 		buff := &bytes.Buffer{}
+		data := map[string]string{
+			"Message": "This is the rich message again",
+			"Footer":  "The footer of the email!",
+		}
+		t.Execute(buf, data)
 
-		app.Render(buff, "body.html", iris.Map{
-			"Message": " his is the rich message body sent by a template!!",
-			"Footer":  "The footer of this e-mail!",
-		})
+
 		content := buff.String()
 
 		err := mailService.Send("iris e-mail just t3st subject", content, to...)


### PR DESCRIPTION
fix the following error:
```
Error:
manually call of Render for a template: 'body.html' without specified RenderPolicy!
Please .Adapt one of the available view engines inside 'kataras/iris/adaptors/view'.
By-default Iris supports five template engines:


```
using  html/template is more simple.

This repository follows the official [golang](https://github.com/golang/go#contributing) guidelines for the contributions:

##### Note that I do not accept pull requests here and that I use the issue tracker proposals only. Please ask questions on the  http://support.iris-go.com or [https://kataras.rocket.chat/channel/iris][chat].

Iris' features are not directly adopted to Iris. A component's feature/change should be tested for some time before being part of the Iris which users install.

Do PRs at the iris' components instead of the core.
You can find many repositories to help Iris with your contribution. The [iris-contrib](https://github.com/iris-contrib) is open for any
kind of PR, community is 100% responsible for the whole organisation.

- [Community iris-specific middleware](https://github.com/iris-contrib/middleware/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue)
- [App reloader and command line tool](https://github.com/kataras/rizla/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue)
- [View Engine](https://github.com/kataras/go-template/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue)
- [Sessions](https://github.com/kataras/go-sessions/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue)
- [For docs.iris-go.com](https://github.com/iris-contrib/gitbook/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue)
- [For examples](https://github.com/iris-contrib/examples/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue)


 **Only one term to future authors**: A contributor should be responsible and answer to the future users' issues that are relative to her/his code. PR's authors must provide adequate support.
**Users is the most important part, we, as software authors, have to respect them. I don't accept any form of contempt to them(users) by anyone.**
