### PR TITLE
ReadTimeout setting added to go-websocket

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -633,6 +633,9 @@ type WebsocketConfiguration struct {
 	// WriteTimeout time allowed to write a message to the connection.
 	// Default value is 15 * time.Second
 	WriteTimeout time.Duration
+	// ReadTimeout time allowed to read a message from the connection.
+	// Default value is 15 * time.Second
+	ReadTimeout time.Duration
 	// PongTimeout allowed to read the next pong message from the connection
 	// Default value is 60 * time.Second
 	PongTimeout time.Duration
@@ -676,6 +679,13 @@ var (
 	OptionWebsocketWriteTimeout = func(val time.Duration) OptionSet {
 		return func(c *Configuration) {
 			c.Websocket.WriteTimeout = val
+		}
+	}
+	// OptionWebsocketReadTimeout time allowed to read a message from the connection.
+	// Default value is 15 * time.Second
+	OptionWebsocketReadTimeout = func(val time.Duration) OptionSet {
+		return func(c *Configuration) {
+			c.Websocket.ReadTimeout = val
 		}
 	}
 	// OptionWebsocketPongTimeout allowed to read the next pong message from the connection
@@ -751,6 +761,8 @@ var (
 const (
 	// DefaultWriteTimeout 15 * time.Second
 	DefaultWriteTimeout = 15 * time.Second
+	// DefaultReadTimeout 15 * time.Second
+	DefaultReadTimeout = 15 * time.Second
 	// DefaultPongTimeout 60 * time.Second
 	DefaultPongTimeout = 60 * time.Second
 	// DefaultPingPeriod (DefaultPongTimeout * 9) / 10
@@ -788,6 +800,7 @@ var (
 func DefaultWebsocketConfiguration() WebsocketConfiguration {
 	return WebsocketConfiguration{
 		WriteTimeout:    DefaultWriteTimeout,
+		ReadTimeout:     DefaultReadTimeout,
 		PongTimeout:     DefaultPongTimeout,
 		PingPeriod:      DefaultPingPeriod,
 		MaxMessageSize:  DefaultMaxMessageSize,

--- a/context_test.go
+++ b/context_test.go
@@ -772,7 +772,7 @@ func TestTemplatesDisabled(t *testing.T) {
 	file := "index.html"
 	ip := "0.0.0.0"
 	errTmpl := "<h2>Template: %s\nIP: %s</h2><b>%s</b>"
-	expctedErrMsg := fmt.Sprintf(errTmpl, file, ip, "Error: Unable to execute a template. Trace: Templates are disabled '.Config.DisableTemplatesEngines = true' please turn that to false, as defaulted.\n")
+	expctedErrMsg := fmt.Sprintf(errTmpl, file, ip, "error: Unable to execute a template. Trace: Templates are disabled '.Config.DisableTemplatesEngines = true' please turn that to false, as defaulted.\n")
 
 	iris.Get("/renderErr", func(ctx *iris.Context) {
 		ctx.MustRender(file, nil)

--- a/websocket.go
+++ b/websocket.go
@@ -102,6 +102,7 @@ func (s *WebsocketServer) RegisterTo(station *Framework, c WebsocketConfiguratio
 
 	s.Server.Set(websocket.Config{
 		WriteTimeout:    c.WriteTimeout,
+		ReadTimeout:     c.ReadTimeout,
 		PongTimeout:     c.PongTimeout,
 		PingPeriod:      c.PingPeriod,
 		MaxMessageSize:  c.MaxMessageSize,


### PR DESCRIPTION
This is a fairly short patch which enables setting the config option for ReadTimeout via iris.Config.Websocket.ReadTimeout. The setting was added to go-websocket and is available in iris v6 but the change was not made in the v5 branch. 