### PR TITLE
Resolve Django `include` and `extends` tags problem

### DIFF
--- a/view/django.go
+++ b/view/django.go
@@ -230,12 +230,8 @@ func (s *DjangoEngine) loadAssets() error {
 	virtualDirectory, virtualExtension := s.directory, s.extension
 	assetFn, namesFn := s.assetFn, s.namesFn
 
-	var templateErr error
-	/*fsLoader, err := pongo2.NewLocalFileSystemLoader(virtualDirectory)
-	if err != nil {
-		return err
-	}*/
-	set := pongo2.NewSet("", pongo2.DefaultLoader)
+	// Make a file set with a template loader based on asset function
+	set := pongo2.NewSet("", &tDjangoAssetLoader{baseDir: s.directory, assetGet: s.assetFn})
 	set.Globals = getPongoContext(s.globals)
 
 	// set the filters
@@ -255,6 +251,8 @@ func (s *DjangoEngine) loadAssets() error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	var templateErr error
 
 	names := namesFn()
 	for _, path := range names {

--- a/view/django.go
+++ b/view/django.go
@@ -1,10 +1,12 @@
 package view
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
+	stdPath "path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -21,6 +23,35 @@ type (
 	// FilterFunction conversion for pongo2.FilterFunction
 	FilterFunction func(in *Value, param *Value) (out *Value, err *Error)
 )
+
+type tDjangoAssetLoader struct {
+	baseDir  string
+	assetGet func(name string) ([]byte, error)
+}
+
+// Abs calculates the path to a given template. Whenever a path must be resolved
+// due to an import from another template, the base equals the parent template's path.
+func (dal *tDjangoAssetLoader) Abs(base, name string) string {
+	if stdPath.IsAbs(name) {
+		return name
+	}
+
+	return stdPath.Join(dal.baseDir, name)
+}
+
+// Get returns an io.Reader where the template's content can be read from.
+func (dal *tDjangoAssetLoader) Get(path string) (io.Reader, error) {
+	if stdPath.IsAbs(path) {
+		path = path[1:]
+	}
+
+	res, err := dal.assetGet(path)
+	if err {
+		return nil, err
+	}
+
+	return bytes.NewBuffer(res), nil
+}
 
 // DjangoEngine contains the amber view engine structure.
 type DjangoEngine struct {

--- a/view/django.go
+++ b/view/django.go
@@ -46,7 +46,7 @@ func (dal *tDjangoAssetLoader) Get(path string) (io.Reader, error) {
 	}
 
 	res, err := dal.assetGet(path)
-	if err {
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This fixes [Issue #681](https://github.com/kataras/iris/issues/681). The problems was due to the template loader. A new template loader based on asset function getter has been implemented.

That code was used as test:
```go
package main

import (
	"github.com/kataras/iris"
	"github.com/kataras/iris/context"
	"os"
)

var files = map[string]string{
	"views/parent.html": `<!DOCTYPE html>
		<html>
			<head>
				<title>Iris with Pongo2 template engine</title>
			    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
			    <meta http-equiv="Pragma" content="no-cache">
			    <meta http-equiv="cache-control" content="no-cache">
			</head>
			<body>
				{% block body %}{% endblock %}
			</body>
		</html>`,

	"views/include.html": "Hello World !",

	"views/child.html": `{% extends "parent.html" %}
		{% block body %}
			{% include "include.html" %}
		{% endblock %}`,
}

func get_names() []string {
	var res []string

	for name := range files {
		res = append(res, name)
	}

	return res
}

func get_files(name string) ([]byte, error) {
	content, exists := files[name]
	if !exists {
		return nil, os.ErrNotExist
	}

	return []byte(content), nil
}

func main() {
	app := iris.New()

	engine := iris.Django("views/", ".html")
	engine.Binary(get_files, get_names)

	app.RegisterView(engine)

	app.Get("/", func(ctx context.Context) {
		ctx.View("child.html")
	})

	app.Run(iris.Addr(":8080"))
}
```