### PR TITLE
Simplify code that resolved issue #683

### DIFF
--- a/context/handler.go
+++ b/context/handler.go
@@ -20,3 +20,123 @@ type Handler func(Context)
 //
 // See `Handler` for more.
 type Handlers []Handler
+
+// HandlerList is a handler list splitted with middlewares at top and other handler at bottom
+// It use an index for traking the bottom start
+type HandlerList struct {
+	handlers         Handlers
+	bottomStartIndex int
+}
+
+// GetHandlers gets the handlers
+func (hl *HandlerList) GetHandlers() Handlers {
+	return hl.handlers
+}
+
+// AddToTop appends to the top the list
+func (hl *HandlerList) AddToTop(handler Handler) *HandlerList {
+	hl.handlers = append(hl.handlers, handler)
+
+	// The bottom is not empty, we must insert handler the right place
+	if len(hl.handlers) != hl.bottomStartIndex {
+		// Shift the bottom, to the bottom of the list ;-)
+		copy(hl.handlers[(hl.bottomStartIndex+1):], hl.handlers[hl.bottomStartIndex:])
+
+		// Place new handler in new cell
+		hl.handlers[hl.bottomStartIndex] = handler
+
+		// Update the top of the bottom
+		hl.bottomStartIndex++
+	}
+
+	return hl
+}
+
+// AddToTop concatenates the top with handler list
+func (hl *HandlerList) AppendToTop(handlers Handlers) *HandlerList {
+	// Size of this list used to concats
+	size := len(hl.handlers)
+
+	// Handler size, we need it for allocating, for updating bottom index,
+	// and so to have the new bottom index
+	handlerSize := len(handlers)
+
+	if handlerSize > 0 {
+		oldBottomIndex := hl.bottomStartIndex
+		hl.bottomStartIndex += handlerSize
+
+		// If the list is empty
+		if size == 0 {
+			// Just copy argument to this list
+			hl.handlers = make(Handlers, len(handlers))
+			copy(hl.handlers, handlers)
+		} else {
+			// Begin by allocating the new list (in all case, that's obvious that we must do it),
+			// and copy the top of the list to the top of the new list
+			newList := make(Handlers, size+handlerSize)
+			copy(newList, hl.handlers)
+
+			// If the bottom is not empty, we must shift the bottom to the bottom of the list to have the new space,
+			// to have empty space needed for the insertion
+			if size != oldBottomIndex {
+				copy(newList[hl.bottomStartIndex:], newList[oldBottomIndex:])
+			}
+
+			// Place the new handlers to the new list at old bottom index,
+			// it works even if the bottom is empty (cause in that case size == hl.bottomStartIndex)
+			copy(newList[oldBottomIndex:], handlers)
+
+			hl.handlers = newList
+		}
+	}
+
+	return hl
+}
+
+// AddToBottom just appends to the list
+func (hl *HandlerList) AddToBottom(handler Handler) *HandlerList {
+	hl.handlers = append(hl.handlers, handler)
+
+	return hl
+}
+
+// AddToBottom concatenates the bottom of the list with handler list, and so
+// concats the whole list with handler list by using existing `joinHandlers` function
+func (hl *HandlerList) AppendToBottom(handlers Handlers) *HandlerList {
+	// Get old size
+	size := len(hl.handlers)
+
+	// Create a new slice of Handlers in order to store all handlers, the already handlers(Handlers) and the new
+	newList := make(Handlers, size+len(handlers))
+
+	// Copy the already Handlers to the just created
+	copy(newList, hl.handlers)
+
+	// Start from there we finish, and store the new Handlers too
+	copy(newList[size:], handlers)
+
+	// Save new list
+	hl.handlers = newList
+
+	return hl
+}
+
+// Copy just copies the instance by copying handler list
+func (hl *HandlerList) Copy() *HandlerList {
+	var newList Handlers
+
+	if len(hl.handlers) > 0 {
+		newList = make(Handlers, len(hl.handlers))
+		copy(newList, hl.handlers)
+	}
+
+	return &HandlerList{
+		handlers:         newList,
+		bottomStartIndex: hl.bottomStartIndex,
+	}
+}
+
+// NewHandlerList creates a new handler list
+func NewHandlerList() *HandlerList {
+	return new(HandlerList)
+}

--- a/context/handler_test.go
+++ b/context/handler_test.go
@@ -1,0 +1,155 @@
+package context
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var (
+	topMessages = []string{
+		"handler-top-1",
+		"handler-top-2",
+		"handler-top-3",
+		"handler-top-4",
+	}
+
+	bottomMessages = []string{
+		"handler-bottom-1",
+		"handler-bottom-2",
+		"handler-bottom-3",
+		"handler-bottom-4",
+	}
+)
+
+type tHandlerTester struct {
+	w bytes.Buffer
+}
+
+func (tester *tHandlerTester) make_handler(message string) Handler {
+	return func(ctx Context) {
+		fmt.Fprintln(&tester.w, message)
+	}
+}
+
+func (tester *tHandlerTester) check(s string) bool {
+	return s == tester.w.String()
+}
+
+func TestHandlerList_Add_TopFirst(t *testing.T) {
+	var tester tHandlerTester
+
+	l := NewHandlerList()
+
+	for i := range topMessages {
+		l.AddToTop(tester.make_handler(topMessages[i]))
+		l.AddToBottom(tester.make_handler(bottomMessages[i]))
+	}
+
+	for _, h := range l.handlers {
+		h(nil)
+	}
+
+	if !tester.check(fmt.Sprintln(strings.Join(append(topMessages, bottomMessages...), fmt.Sprintln("")))) {
+		t.Fail()
+	}
+}
+
+func TestHandlerList_Add_BottomFirst(t *testing.T) {
+	var tester tHandlerTester
+
+	l := NewHandlerList()
+
+	for i := range topMessages {
+		l.AddToBottom(tester.make_handler(bottomMessages[i]))
+		l.AddToTop(tester.make_handler(topMessages[i]))
+	}
+
+	for _, h := range l.handlers {
+		h(nil)
+	}
+
+	if !tester.check(fmt.Sprintln(strings.Join(append(topMessages, bottomMessages...), fmt.Sprintln("")))) {
+		t.Fail()
+	}
+}
+
+func TestHandlerList_Append_TopFirst(t *testing.T) {
+	var tester tHandlerTester
+	var topHandlers, bottomHandlers Handlers
+
+	for _, m := range topMessages {
+		topHandlers = append(topHandlers, tester.make_handler(m))
+	}
+	for _, m := range bottomMessages {
+		bottomHandlers = append(bottomHandlers, tester.make_handler(m))
+	}
+
+	l := NewHandlerList()
+
+	l.AppendToTop(topHandlers[:2])
+	l.AppendToBottom(bottomHandlers[:2])
+	l.AppendToTop(topHandlers[2:])
+	l.AppendToBottom(bottomHandlers[2:])
+
+	for _, h := range l.handlers {
+		if h == nil {
+			continue
+		}
+		h(nil)
+	}
+
+	if !tester.check(fmt.Sprintln(strings.Join(append(topMessages, bottomMessages...), fmt.Sprintln("")))) {
+		t.Fail()
+	}
+}
+
+func TestHandlerList_Append_BottomFirst(t *testing.T) {
+	var tester tHandlerTester
+	var topHandlers, bottomHandlers Handlers
+
+	for _, m := range topMessages {
+		topHandlers = append(topHandlers, tester.make_handler(m))
+	}
+	for _, m := range bottomMessages {
+		bottomHandlers = append(bottomHandlers, tester.make_handler(m))
+	}
+
+	l := NewHandlerList()
+
+	l.AppendToBottom(bottomHandlers[:2])
+	l.AppendToTop(topHandlers[:2])
+	l.AppendToBottom(bottomHandlers[2:])
+	l.AppendToTop(topHandlers[2:])
+
+	for _, h := range l.handlers {
+		if h == nil {
+			continue
+		}
+		h(nil)
+	}
+
+	if !tester.check(fmt.Sprintln(strings.Join(append(topMessages, bottomMessages...), fmt.Sprintln("")))) {
+		t.Fail()
+	}
+}
+
+func TestHandlerList_Copy(t *testing.T) {
+	var tester tHandlerTester
+
+	l := NewHandlerList()
+
+	for i := range topMessages {
+		l.AddToBottom(tester.make_handler(bottomMessages[i]))
+		l.AddToTop(tester.make_handler(topMessages[i]))
+	}
+
+	for _, h := range l.Copy().handlers {
+		h(nil)
+	}
+
+	if !tester.check(fmt.Sprintln(strings.Join(append(topMessages, bottomMessages...), fmt.Sprintln("")))) {
+		t.Fail()
+	}
+}

--- a/core/router/api_builder.go
+++ b/core/router/api_builder.go
@@ -76,15 +76,12 @@ type APIBuilder struct {
 	// to the end-user.
 	reporter *errors.Reporter
 
-	// the per-party handlers, order
-	// of handlers registration matters.
-	middleware context.Handlers
-	// the global middleware handlers, order of call doesn't matters, order
+	// all handlers (middleware, per-perty, etc.) an, order of call doesn't matters, order
 	// of handlers registration matters. We need a secondary field for this
 	// because `UseGlobal` registers handlers that should be executed
 	// even before the `middleware` handlers, and in the same time keep the order
 	// of handlers registration, so the same type of handlers are being called in order.
-	beginGlobalHandlers context.Handlers
+	handlers *context.HandlerList
 	// the per-party routes registry (useful for `Done` and `UseGlobal` only)
 	apiRoutes []*Route
 	// the per-party done handlers, order
@@ -106,6 +103,7 @@ func NewAPIBuilder() *APIBuilder {
 		reporter:          errors.NewReporter(),
 		relativePath:      "/",
 		routes:            new(repository),
+		handlers:          context.NewHandlerList(),
 	}
 
 	return rb
@@ -146,18 +144,13 @@ func (rb *APIBuilder) Handle(method string, registeredPath string, handlers ...c
 
 	fullpath := rb.relativePath + registeredPath // for now, keep the last "/" if any,  "/xyz/"
 
-	// global begin handlers -> middleware that are registered before route registration
-	// -> handlers that are passed to this Handle function.
-	routeHandlers := joinHandlers(append(rb.beginGlobalHandlers, rb.middleware...), handlers)
-	// -> done handlers after all
-	if len(rb.doneGlobalHandlers) > 0 {
-		routeHandlers = append(routeHandlers, rb.doneGlobalHandlers...) // register the done middleware, if any
-	}
+	// Copies handlers
+	routeHandlers := rb.handlers.Copy().AppendToBottom(handlers).AppendToBottom(rb.doneGlobalHandlers)
 
 	// here we separate the subdomain and relative path
 	subdomain, path := splitSubdomainAndPath(fullpath)
 
-	r, err := NewRoute(method, subdomain, path, routeHandlers, rb.macros)
+	r, err := NewRoute(method, subdomain, path, routeHandlers.GetHandlers(), rb.macros)
 	if err != nil { // template path parser errors:
 		rb.reporter.Add("%v -> %s:%s:%s", err, method, subdomain, path)
 		return nil
@@ -198,19 +191,20 @@ func (rb *APIBuilder) Party(relativePath string, handlers ...context.Handler) Pa
 	}
 
 	fullpath := parentPath + relativePath
+
 	// append the parent's + child's handlers
-	middleware := joinHandlers(rb.middleware, handlers)
+	middlewares := rb.handlers.Copy().AppendToBottom(handlers)
 
 	return &APIBuilder{
 		// global/api builder
-		macros:              rb.macros,
-		routes:              rb.routes,
-		errorCodeHandlers:   rb.errorCodeHandlers,
-		beginGlobalHandlers: rb.beginGlobalHandlers,
-		doneGlobalHandlers:  rb.doneGlobalHandlers,
-		reporter:            rb.reporter,
+		macros:             rb.macros,
+		routes:             rb.routes,
+		errorCodeHandlers:  rb.errorCodeHandlers,
+		doneGlobalHandlers: rb.doneGlobalHandlers,
+		reporter:           rb.reporter,
+		// middlewares
+		handlers: middlewares,
 		// per-party/children
-		middleware:   middleware,
 		relativePath: fullpath,
 	}
 }
@@ -275,7 +269,7 @@ func (rb *APIBuilder) GetRoute(routeName string) *Route {
 // Use `UseGlobal` if you want to register begin handlers(middleware)
 // that should be always run before all application's routes.
 func (rb *APIBuilder) Use(middleware ...context.Handler) {
-	rb.middleware = append(rb.middleware, middleware...)
+	rb.handlers.AppendToBottom(context.Handlers(middleware))
 }
 
 // Done appends to the very end, Handler(s) to the current Party's routes and child routes
@@ -300,7 +294,7 @@ func (rb *APIBuilder) UseGlobal(handlers ...context.Handler) {
 		r.use(handlers) // prepend the handlers to the existing routes
 	}
 	// set as begin handlers for the next routes as well.
-	rb.beginGlobalHandlers = append(rb.beginGlobalHandlers, handlers...)
+	rb.handlers.AppendToTop(context.Handlers(handlers))
 }
 
 // None registers an "offline" route
@@ -725,17 +719,4 @@ func (rb *APIBuilder) Layout(tmplLayoutFile string) Party {
 	})
 
 	return rb
-}
-
-// joinHandlers uses to create a copy of all Handlers and return them in order to use inside the node
-func joinHandlers(Handlers1 context.Handlers, Handlers2 context.Handlers) context.Handlers {
-	nowLen := len(Handlers1)
-	totalLen := nowLen + len(Handlers2)
-	// create a new slice of Handlers in order to store all handlers, the already handlers(Handlers) and the new
-	newHandlers := make(context.Handlers, totalLen)
-	//copy the already Handlers to the just created
-	copy(newHandlers, Handlers1)
-	//start from there we finish, and store the new Handlers too
-	copy(newHandlers[nowLen:], Handlers2)
-	return newHandlers
 }


### PR DESCRIPTION
I saw code for solving #683. I noticed that's used 2 lists of handlers (beginGlobalHandlers and middleware).

I offer here a simpler version that uses only one list and which conserve order of calls of the `UseGlobal` method.