### PR TITLE
Add shutdown handler registration for Application

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -232,6 +232,13 @@ func WithoutRemoteAddrHeader(headerName string) Configurator {
 	}
 }
 
+// WithShutdownHandler register an on-shutdown handler
+func WithShutdownHandler(handler OnShutdown) Configurator {
+	return func(app *Application) {
+		app.RegisterOnShutdown(handler)
+	}
+}
+
 // WithOtherValue adds a value based on a key to the Other setting.
 //
 // See `Configuration`.


### PR DESCRIPTION
This fixes up #688 .

A method on Application has been added to delay shutdown handler registration on Host Supervisor.

This allow to register a shutdown handler from a middleware.