### PR TITLE
Update i18n middleware and toolkit methods to support IETF and RFC2616.

### DIFF
--- a/middleware/i18n/i18n.go
+++ b/middleware/i18n/i18n.go
@@ -31,9 +31,16 @@ func (i *i18nMiddleware) ServeHTTP(ctx context.Context) {
 			if len(language) > 0 {
 				wasByCookie = true
 			} else {
-				// try to get by the request headers(?)
-				if langHeader := ctx.GetHeader("Accept-Language"); i18n.IsExist(langHeader) {
-					language = langHeader
+				// try to get by the request headers.
+				langHeader := ctx.GetHeader("Accept-Language")
+				if len(langHeader) > 0 {
+					for _, langEntry := range strings.Split(langHeader, ",") {
+						lc := strings.Split(langEntry, ";")[0]
+						if lc, ok := i18n.IsExistSimilar(lc); ok {
+							language = lc
+							break
+						}
+					}
 				}
 			}
 		}

--- a/vendor/github.com/Unknwon/i18n/i18n.go
+++ b/vendor/github.com/Unknwon/i18n/i18n.go
@@ -126,6 +126,27 @@ func IsExist(lang string) bool {
 	return ok
 }
 
+// IsExistSimilar returns true if the language, or something similar
+// exists (e.g. en-US maps to en).
+// it returns the found name and whether it was able to match something.
+func IsExistSimilar(lang string) (string, bool) {
+	_, ok := locales.store[lang]
+	if ok {
+		return lang, true
+	}
+
+	// remove the internationalization element from the IETF code
+	code := strings.Split(lang, "-")[0]
+
+	for _, lc := range locales.store {
+		if strings.Contains(lc.lang, code) {
+			return lc.lang, true
+		}
+	}
+
+	return "", false
+}
+
 // IndexLang returns index of language locale,
 // it returns -1 if locale not exists.
 func IndexLang(lang string) int {


### PR DESCRIPTION
* Add IETF matching method to vendor unkwon/i18n.
* Update i18n middleware to support RFC2616.

Solves [issue 696](https://github.com/kataras/iris/issues/696)