### PR TITLE
bugfix: trim relative slash incorrectly in apiBuilder.Party

### DIFF
--- a/core/router/api_builder.go
+++ b/core/router/api_builder.go
@@ -214,8 +214,8 @@ func (api *APIBuilder) Party(relativePath string, handlers ...context.Handler) P
 	}
 
 	// this is checked later on but for easier debug is better to do it here:
-	if api.relativePath[0] == '/' && relativePath[0] == '/' {
-		parentPath = parentPath[1:] // remove  first slash if parent ended with / and new one started with /.
+	if api.relativePath[len(api.relativePath)-1] == '/' && relativePath[0] == '/' {
+		relativePath = relativePath[1:] // remove first slash if parent ended with / and new one started with /.
 	}
 
 	// if it's subdomain then it has priority, i.e:


### PR DESCRIPTION
According to your comments, we should remove the redundant slash before `relativePath`.

The previous code doesn't make sense... If so, the code below:

```go
api := app.Party("/api")
api.PartyFunc("/endpoint", func(route router.Party){
    route.Get("/", someHandler)
})
```

will generate route `GET /endpoint` without prefix `/api`. 

The nested routes defined by `PartyFunc` will also be built unexpected.