### PR TITLE
Fix issue #757

### DIFF
--- a/iris.go
+++ b/iris.go
@@ -470,7 +470,7 @@ type Runner func(*Application) error
 func Listener(l net.Listener, hostConfigs ...host.Configurator) Runner {
 	return func(app *Application) error {
 		app.config.vhost = netutil.ResolveVHost(l.Addr().String())
-		return app.NewHost(new(http.Server)).
+		return app.NewHost(&http.Server{Addr: l.Addr().String()}).
 			Configure(hostConfigs...).
 			Serve(l)
 	}


### PR DESCRIPTION
Fix incorrect host in "Now listening on:" message when using iris.Listener described in issue 757
