### PR TITLE
Get pongo2's origin data type

### DIFF
--- a/view/django.go
+++ b/view/django.go
@@ -44,6 +44,22 @@ type (
 	TagParser func(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Error)
 )
 
+func (value *Value) GetValue() *pongo2.Value {
+	return (*pongo2.Value)(value)
+}
+
+func (error *Error) GetError() *pongo2.Error {
+	return (*pongo2.Error)(error)
+}
+
+func (parser *Parser) GetParser() *pongo2.Parser {
+	return (*pongo2.Parser)(parser)
+}
+
+func (token *Token) GetToken() *pongo2.Token {
+	return (*pongo2.Token)(token)
+}
+
 type tDjangoAssetLoader struct {
 	baseDir  string
 	assetGet func(name string) ([]byte, error)


### PR DESCRIPTION
#764 

I've added implementations to all 4 types defined above.

For instance, I only need to get `*pongo2.Value` and `*pongo2.Error`, but I think the others might be needed later.