### PR TITLE
websocket disconnect/leave-all-rooms should delete empty rooms as well otherwise rooms hash goes ever growing

### DIFF
--- a/websocket/server.go
+++ b/websocket/server.go
@@ -259,17 +259,8 @@ func (s *Server) join(roomName string, connID string) {
 // LeaveAll kicks out a connection from ALL of its joined rooms
 func (s *Server) LeaveAll(connID string) {
 	s.mu.Lock()
-	for name, connectionIDs := range s.rooms {
-		for i := range connectionIDs {
-			if connectionIDs[i] == connID {
-				// fire the on room leave connection's listeners
-				s.connections.get(connID).fireOnLeave(name)
-				// the connection is inside this room, lets remove it
-				if i < len(s.rooms[name]) {
-					s.rooms[name] = append(s.rooms[name][:i], s.rooms[name][i+1:]...)
-				}
-			}
-		}
+	for name, _ := range s.rooms {
+		s.leave(name, connID)
 	}
 	s.mu.Unlock()
 }


### PR DESCRIPTION
websocket/server.leave() already has the code to remove a connection from the room, and in case it's the last connection in the room then also remove the room from the server rooms hash table.

however websocket/server.LeaveAll() duplicated the code to remove the connection from the room but without removing the room itself from the hash table if it's then empty. note that with the current architecture the rooms hash isn't used just for rooms but it's for every single websocket connection as well. so this makes the rooms hash ever growing with every connection and re-connection. (a hash key pointing to an empty array value)

this commit is to simply re-use server.leave() from server.LeaveAll(), it already fixes the ever-growing-hash issue.

