### PR TITLE
Fix dep dependency

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,8 +63,8 @@
   name = "github.com/ryanuber/columnize"
 
 [[constraint]]
-  branch = "v1.2.0"
   name = "github.com/satori/go.uuid"
+  version = "1.2.0"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
Version reference must be written in a version key. Otherwise, `dep ensure` can't solve dependency tree because «go.uuid» package doesn't have a branch «v1.2.0».

```
Solving failure: No versions of github.com/satori/go.uuid met constraints:
        v1.2.0: Could not introduce github.com/satori/go.uuid@v1.2.0, as it is not allowed by constraints from the following projects:
        v1.2.0 from github.com/kataras/iris@dev
        v1.2.0 from github.com/kataras/iris@dev

        v1.1.0: Could not introduce github.com/satori/go.uuid@v1.1.0, as it is not allowed by constraints from the following projects:
        v1.2.0 from github.com/kataras/iris@dev
        v1.2.0 from github.com/kataras/iris@dev

        v1.0.0: Could not introduce github.com/satori/go.uuid@v1.0.0, as it is not allowed by constraints from the following projects:
        v1.2.0 from github.com/kataras/iris@dev
        v1.2.0 from github.com/kataras/iris@dev

        master: Could not introduce github.com/satori/go.uuid@master, as it is not allowed by constraints from the following projects:
        v1.2.0 from github.com/kataras/iris@dev
        v1.2.0 from github.com/kataras/iris@dev
```