### PR TITLE
corrected spelling for example docs

### DIFF
--- a/_examples/miscellaneous/recover/main.go
+++ b/_examples/miscellaneous/recover/main.go
@@ -12,7 +12,7 @@ func main() {
 	app.Use(recover.New())
 
 	i := 0
-	// let's simmilate a panic every next request
+	// let's simulate a panic every next request
 	app.Get("/", func(ctx iris.Context) {
 		i++
 		if i%2 == 0 {


### PR DESCRIPTION
Corrected spelling from simmilate to simulate

# We'd love to see more contributions

Read how you can [contribute to the project](https://github.com/kataras/blob/master/CONTRIBUTING.md).

> Please attach an [issue](https://github.com/kataras/iris/issues) link which your PR solves otherwise your work may be rejected.