### PR TITLE
Update gzip_response_writer.go

### DIFF
--- a/context/gzip_response_writer.go
+++ b/context/gzip_response_writer.go
@@ -108,7 +108,7 @@ func (w *GzipResponseWriter) EndResponse() {
 func (w *GzipResponseWriter) Write(contents []byte) (int, error) {
 	// save the contents to serve them (only gzip data here)
 	w.chunks = append(w.chunks, contents...)
-	return len(w.chunks), nil
+	return len(contents), nil
 }
 
 // Writef formats according to a format specifier and writes to the response.


### PR DESCRIPTION
The Context.SendFile function Send file size more than 65536 byte with bug.
Because it calls the io.copyBuffer method.
In order to solve this problem, it took me a day.

Please see:
```golang
// copyBuffer is the actual implementation of Copy and CopyBuffer.
// if buf is nil, one is allocated.
func copyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error) {
	// If the reader has a WriteTo method, use it to do the copy.
	// Avoids an allocation and a copy.
	if wt, ok := src.(WriterTo); ok {
		return wt.WriteTo(dst)
	}
	// Similarly, if the writer has a ReadFrom method, use it to do the copy.
	if rt, ok := dst.(ReaderFrom); ok {
		return rt.ReadFrom(src)
	}
	if buf == nil {
		buf = make([]byte, 32*1024)
	}
	for {
		nr, er := src.Read(buf)
		if nr > 0 {
			nw, ew := dst.Write(buf[0:nr])
			if nw > 0 {
				written += int64(nw)
			}
			if ew != nil {
				err = ew
				break
			}
			if nr != nw {
				err = ErrShortWrite
				break
			}
		}
		if er != nil {
			if er != EOF {
				err = er
			}
			break
		}
	}
	return written, err
}
```

# We'd love to see more contributions

Read how you can [contribute to the project](https://github.com/kataras/blob/master/CONTRIBUTING.md).

> Please attach an [issue](https://github.com/kataras/iris/issues) link which your PR solves otherwise your work may be rejected.