### PR TITLE
Fixed Some Typos

### DIFF
--- a/_examples/experimental-handlers/jwt/main.go
+++ b/_examples/experimental-handlers/jwt/main.go
@@ -1,4 +1,4 @@
-// iris provides some basic middleware, most for your learning courve.
+// iris provides some basic middleware, most for your learning curve.
 // You can use any net/http compatible middleware with iris.FromStd wrapper.
 //
 // JWT net/http video tutorial for golang newcomers: https://www.youtube.com/watch?v=dgJFeqeXVKw
@@ -43,4 +43,4 @@ func main() {
 
 	app.Get("/ping", myHandler)
 	app.Run(iris.Addr("localhost:3001"))
-} // don't forget to look ../jwt_test.go to seee how to set your own custom claims
+} // don't forget to look ../jwt_test.go to see how to set your own custom claims


### PR DESCRIPTION
Not sure if this sentence is right 

`// iris provides some basic middleware, most for your learning curve.`
Maybe you meant something like
` // iris provides some basic middleware to help newcomers understand the concepts.`
But I wasn't sure so I left the sentence alone (exepct for the typo lol)

# We'd love to see more contributions

Read how you can [contribute to the project](https://github.com/kataras/blob/master/CONTRIBUTING.md).

> Please attach an [issue](https://github.com/kataras/iris/issues) link which your PR solves otherwise your work may be rejected.