### PR TITLE
fix / lifetime.Time not updated on expiration shift

### DIFF
--- a/sessions/lifetime.go
+++ b/sessions/lifetime.go
@@ -43,6 +43,7 @@ func (lt *LifeTime) Revive(onExpire func()) {
 // Shift resets the lifetime based on "d".
 func (lt *LifeTime) Shift(d time.Duration) {
 	if d > 0 && lt.timer != nil {
+		lt.Time = time.Now().Add(d)
 		lt.timer.Reset(d)
 	}
 }

--- a/sessions/sessiondb/redis/service/service.go
+++ b/sessions/sessiondb/redis/service/service.go
@@ -201,7 +201,7 @@ func (r *Service) getKeysConn(c redis.Conn, prefix string) ([]string, error) {
 			if keysSliceAsBytes, ok := keysInterface[1].([]interface{}); ok {
 				keys := make([]string, len(keysSliceAsBytes), len(keysSliceAsBytes))
 				for i, k := range keysSliceAsBytes {
-					keys[i] = fmt.Sprintf("%s", k)
+					keys[i] = fmt.Sprintf("%s", k)[len(r.Config.Prefix):]
 				}
 
 				return keys, nil


### PR DESCRIPTION
While lifetime.Shift resets the underlying timer it should also update the Time property itself.