### PR TITLE
various fixes on redis as sessions db

### DIFF
--- a/sessions/lifetime.go
+++ b/sessions/lifetime.go
@@ -43,6 +43,7 @@ func (lt *LifeTime) Revive(onExpire func()) {
 // Shift resets the lifetime based on "d".
 func (lt *LifeTime) Shift(d time.Duration) {
 	if d > 0 && lt.timer != nil {
+		lt.Time = time.Now().Add(d)
 		lt.timer.Reset(d)
 	}
 }

--- a/sessions/sessiondb/redis/service/service.go
+++ b/sessions/sessiondb/redis/service/service.go
@@ -201,7 +201,7 @@ func (r *Service) getKeysConn(c redis.Conn, prefix string) ([]string, error) {
 			if keysSliceAsBytes, ok := keysInterface[1].([]interface{}); ok {
 				keys := make([]string, len(keysSliceAsBytes), len(keysSliceAsBytes))
 				for i, k := range keysSliceAsBytes {
-					keys[i] = fmt.Sprintf("%s", k)
+					keys[i] = fmt.Sprintf("%s", k)[len(r.Config.Prefix):]
 				}
 
 				return keys, nil


### PR DESCRIPTION
1. lifetime.Time not updated on expiration shift

2. redis service.TTL() return values were incorrect and incompatible wtih its consumers such as redis database.Acquire(); this fix re-aligns the return values so:
- hasExpiration means there's a ttl value (i.e. > -1)
- found means the key is found, i.e. not(redis cmd error || ttl expired)

3. redis service.getKeysConn() previously returned keys as is from scanning the db
- inside getKeysConn() it scans redis with "r.Config.Prefix+prefix"
- previously it returned the found keys as is
- then UpdateTTLMany() would call updateTTLConn() with such keys
- and updateTTLConn() would again perform redis expire with "r.Config.Prefix+key"
- this causes the redis expire to always fail as the call to redis expire would be with duplicated prefixes
- with this fix service.getKeysConn() expects a passed in key param without config.prefix, and also return keys without config.prefix, so things are aligned and config.prefix won't get duplicated



