### PR TITLE
add part function in html.go   for extending block in layout 

### DIFF
--- a/view/html.go
+++ b/view/html.go
@@ -44,6 +44,9 @@ var emptyFuncs = template.FuncMap{
 	"yield": func() (string, error) {
 		return "", fmt.Errorf("yield was called, yet no layout defined")
 	},
+	"part": func() (string, error) {
+		return "", fmt.Errorf("block was called, yet no layout defined")
+	},
 	"partial": func() (string, error) {
 		return "", fmt.Errorf("block was called, yet no layout defined")
 	},
@@ -387,6 +390,15 @@ func (s *HTMLEngine) layoutFuncsFor(name string, binding interface{}) {
 		"yield": func() (template.HTML, error) {
 			buf, err := s.executeTemplateBuf(name, binding)
 			// Return safe HTML here since we are rendering our own template.
+			return template.HTML(buf.String()), err
+		},
+		"part": func(partName string) (template.HTML, error) {
+			nameTemp := strings.Replace(name, ".html", "", -1)
+			fullPartName := fmt.Sprintf("%s-%s", nameTemp, partName)
+			buf, err := s.executeTemplateBuf(fullPartName, binding)
+			if err != nil {
+				return "", nil
+			}
 			return template.HTML(buf.String()), err
 		},
 		"current": func() (string, error) {


### PR DESCRIPTION
layout.html 
 <head>
    {{ part "css" }}
</head>

home/index.html
{{ define "home/index-css"}}
<link rel="stylesheet" type="text/css" href="/public/css/home/index.css" />
{{ end }} 

in html/temple  the defined block is global variable， so the way of "{{ block "css" }}" in layout and "{{ define "css"}}{{end}}" in home/index.html and home/about.html   just one definition work, others will be over coved。  No use！！！

This part function like extend the block in layout.
