### PR TITLE
session/redis: fix unused service config var. IdleTimeout witch was r…

### DIFF
--- a/sessions/sessiondb/redis/service/service.go
+++ b/sessions/sessiondb/redis/service/service.go
@@ -292,7 +292,7 @@ func (r *Service) Connect() {
 		c.Addr = DefaultRedisAddr
 	}
 
-	pool := &redis.Pool{IdleTimeout: DefaultRedisIdleTimeout, MaxIdle: c.MaxIdle, MaxActive: c.MaxActive}
+	pool := &redis.Pool{IdleTimeout: c.IdleTimeout, MaxIdle: c.MaxIdle, MaxActive: c.MaxActive}
 	pool.TestOnBorrow = func(c redis.Conn, t time.Time) error {
 		_, err := c.Do("PING")
 		return err


### PR DESCRIPTION
…eplaced by default values

# We'd love to see more contributions

> Please attach an [issue](https://github.com/kataras/iris/issues) link which your PR solves otherwise your work may be rejected.

https://github.com/kataras/iris/issues/1139