### PR TITLE
Fix cache corruption due to recorder reuse

### DIFF
--- a/cache/entry/entry.go
+++ b/cache/entry/entry.go
@@ -115,7 +115,8 @@ func (e *Entry) Reset(statusCode int, headers map[string][]string,
 		e.response.headers = newHeaders
 	}
 
-	e.response.body = body
+	e.response.body = make([]byte,len(body))
+	copy(e.response.body, body)
 	// check if a given life changer provided
 	// and if it does then execute the change life time
 	if lifeChanger != nil {


### PR DESCRIPTION
Currently, the body of a cache entry is set to the `chunks` of a request recorder.

```
body := recorder.Body() // <- recorder.chunks (which is reused)

e.response.body = body
```

However recorders are reused. If now a recorder is being reused and a cache entry points to a slice of the same array that is used to record the new request the cache entry is overwritten thereby corrupting the cache.

We need to copy the body to avoid this and make the cache entry immutable.

