### PR TITLE
Update fs.go

### DIFF
--- a/core/router/fs.go
+++ b/core/router/fs.go
@@ -773,14 +773,14 @@ func serveFile(ctx context.Context, fs http.FileSystem, name string, redirect bo
 		}
 	}
 
-	// redirect if the directory name doesn't end in a slash
-	if d.IsDir() {
-		url := ctx.Request().URL.Path
-		if url[len(url)-1] != '/' {
-			localRedirect(ctx, path.Base(url)+"/")
-			return "", http.StatusMovedPermanently
-		}
-	}
+	//// redirect if the directory name doesn't end in a slash
+	//if d.IsDir() {
+	//	url := ctx.Request().URL.Path
+	//	if url[len(url)-1] != '/' {
+	//		localRedirect(ctx, path.Base(url)+"/")
+	//		return "", http.StatusMovedPermanently
+	//	}
+	//}
 
 	// use contents of index.html for directory, if present
 	if d.IsDir() {


### PR DESCRIPTION
When request index.html file of static resources directories, it is always redirect to the wrong path, such as:
GET /public/html/index.html [ok]
RESPONSE Location: ./    --> GET /public/html/ [ok] code line: 744
RESPONSE Location: html/  --> GET /public/html/html/ [error] code line: 780
Bug:
ctx.Request().URL.Path never end with "/" 
ctx.Request().URL.Path has been changed by core/router/handler.go line 154-156
`
path = "/" + strings.Trim(path, "/")

r.URL.Path = path
`

# We'd love to see more contributions

Read how you can [contribute to the project](https://github.com/kataras/blob/master/CONTRIBUTING.md).

> Please attach an [issue](https://github.com/kataras/iris/issues) link which your PR solves otherwise your work may be rejected.