### PR TITLE
#1303 Fixed. Could not build the url-shortener code. Error was being …

### DIFF
--- a/_examples/tutorial/url-shortener/factory.go
+++ b/_examples/tutorial/url-shortener/factory.go
@@ -11,7 +11,7 @@ type Generator func() string
 
 // DefaultGenerator is the defautl url generator
 var DefaultGenerator = func() string {
-	id, _ := uuid.NewV4()
+	id := uuid.NewV4()
 	return id.String()
 }
 


### PR DESCRIPTION
Fixed the issue. Could not build the url-shortener code. Error was being thrown pertaining to `uuid.NewV4()` second assignment value . The `uuid.NewV4()` only has one value assignment. Removed the `_` assignment and kept `id :=`.