### PR TITLE
Problem Details for HTTP APIs (v11.2.5)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,13 @@ Developers are not forced to upgrade if they don't really need it. Upgrade whene
 
 **How to upgrade**: Open your command-line and execute this command: `go get github.com/kataras/iris@master`.
 
+# Mo, 12 August 2019 | v11.2.5
+
+- [New Feature: Problem Details for HTTP APIs based](https://github.com/kataras/iris/pull/1336)
+- [Add Context.AbsoluteURI](https://github.com/kataras/iris/pull/1336/files#diff-15cce7299aae8810bcab9b0bf9a2fdb1R2368)
+
+Commit log: https://github.com/kataras/iris/compare/v11.2.4...v11.2.5
+
 # Fr, 09 August 2019 | v11.2.4
 
 - Fixes [iris.Jet: no view engine found for '.jet' or '.html'](https://github.com/kataras/iris/issues/1327)

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-11.2.4:https://github.com/kataras/iris/releases/tag/v11.2.4
+11.2.5:https://github.com/kataras/iris/releases/tag/v11.2.5

--- a/_examples/routing/http-errors/main.go
+++ b/_examples/routing/http-errors/main.go
@@ -7,12 +7,15 @@ import (
 func main() {
 	app := iris.New()
 
+	// Catch a specific error code.
 	app.OnErrorCode(iris.StatusInternalServerError, func(ctx iris.Context) {
 		ctx.HTML("Message: <b>" + ctx.Values().GetString("message") + "</b>")
 	})
 
+	// Catch all error codes [app.OnAnyErrorCode...]
+
 	app.Get("/", func(ctx iris.Context) {
-		ctx.HTML(`Click <a href="/my500">here</a> to fire the 500 status code`)
+		ctx.HTML(`Click <a href="/my500">here</a> to pretend an HTTP error`)
 	})
 
 	app.Get("/my500", func(ctx iris.Context) {
@@ -24,5 +27,60 @@ func main() {
 		ctx.Writef("Hello %s", ctx.Params().Get("firstname"))
 	})
 
+	app.Get("/product-problem", problemExample)
+
+	app.Get("/product-error", func(ctx iris.Context) {
+		ctx.Writef("explain the error")
+	})
+
+	// http://localhost:8080
+	// http://localhost:8080/my500
+	// http://localhost:8080/u/gerasimos
+	// http://localhost:8080/product-problem
 	app.Run(iris.Addr(":8080"))
+}
+
+func newProductProblem(productName, detail string) iris.Problem {
+	return iris.NewProblem().
+		// The type URI, if relative it automatically convert to absolute.
+		Type("/product-error").
+		// The title, if empty then it gets it from the status code.
+		Title("Product validation problem").
+		// Any optional details.
+		Detail(detail).
+		// The status error code, required.
+		Status(iris.StatusBadRequest).
+		// Any custom key-value pair.
+		Key("productName", productName)
+	// Optional cause of the problem, chain of Problems.
+	// Cause(iris.NewProblem().Type("/error").Title("cause of the problem").Status(400))
+}
+
+func problemExample(ctx iris.Context) {
+	/*
+		p := iris.NewProblem().
+			Type("/validation-error").
+			Title("Your request parameters didn't validate").
+			Detail("Optional details about the error.").
+			Status(iris.StatusBadRequest).
+		 	Key("customField1", customValue1)
+		 	Key("customField2", customValue2)
+		ctx.Problem(p)
+
+		// OR
+		ctx.Problem(iris.Problem{
+			"type":   "/validation-error",
+			"title":  "Your request parameters didn't validate",
+			"detail": "Optional details about the error.",
+			"status": iris.StatusBadRequest,
+		 	"customField1": customValue1,
+		 	"customField2": customValue2,
+		})
+
+		// OR
+	*/
+
+	// Response like JSON but with indent of "  " and
+	// content type of "application/problem+json"
+	ctx.Problem(newProductProblem("product name", "problem error details"))
 }

--- a/context/problem.go
+++ b/context/problem.go
@@ -1,0 +1,172 @@
+package context
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Problem Details for HTTP APIs.
+// Pass a Problem value to `context.Problem` to
+// write an "application/problem+json" response.
+//
+// Read more at: https://github.com/kataras/iris/wiki/Routing-error-handlers
+type Problem map[string]interface{}
+
+// NewProblem retruns a new Problem.
+// Head over to the `Problem` type godoc for more.
+func NewProblem() Problem {
+	p := make(Problem)
+	return p
+}
+
+func (p Problem) keyExists(key string) bool {
+	if p == nil {
+		return false
+	}
+
+	_, found := p[key]
+	return found
+}
+
+// DefaultProblemStatusCode is being sent to the client
+// when Problem's status is not a valid one.
+var DefaultProblemStatusCode = http.StatusBadRequest
+
+func (p Problem) getStatus() (int, bool) {
+	statusField, found := p["status"]
+	if !found {
+		return DefaultProblemStatusCode, false
+	}
+
+	status, ok := statusField.(int)
+	if !ok {
+		return DefaultProblemStatusCode, false
+	}
+
+	if !StatusCodeNotSuccessful(status) {
+		return DefaultProblemStatusCode, false
+	}
+
+	return status, true
+}
+
+func isEmptyTypeURI(uri string) bool {
+	return uri == "" || uri == "about:blank"
+}
+
+func (p Problem) getType() string {
+	typeField, found := p["type"]
+	if found {
+		if typ, ok := typeField.(string); ok {
+			if !isEmptyTypeURI(typ) {
+				return typ
+			}
+		}
+	}
+
+	return ""
+}
+
+// Updates "type" field to absolute URI, recursively.
+func (p Problem) updateTypeToAbsolute(ctx Context) {
+	if p == nil {
+		return
+	}
+
+	if uriRef := p.getType(); uriRef != "" {
+		p.Type(ctx.AbsoluteURI(uriRef))
+	}
+
+	if cause, ok := p["cause"]; ok {
+		if causeP, ok := cause.(Problem); ok {
+			causeP.updateTypeToAbsolute(ctx)
+		}
+	}
+}
+
+// Key sets a custom key-value pair.
+func (p Problem) Key(key string, value interface{}) Problem {
+	p[key] = value
+	return p
+}
+
+// Type URI SHOULD resolve to HTML [W3C.REC-html5-20141028]
+// documentation that explains how to resolve the problem.
+// Example: "https://example.net/validation-error"
+//
+// Empty URI or "about:blank", when used as a problem type,
+// indicates that the problem has no additional semantics beyond that of the HTTP status code.
+// When "about:blank" is used,
+// the title is being automatically set the same as the recommended HTTP status phrase for that code
+// (e.g., "Not Found" for 404, and so on) on `Status` call.
+//
+// Relative paths are also valid when writing this Problem to an Iris Context.
+func (p Problem) Type(uri string) Problem {
+	return p.Key("type", uri)
+}
+
+// Title sets the problem's title field.
+// Example: "Your request parameters didn't validate."
+// It is set to status Code text if missing,
+// (e.g., "Not Found" for 404, and so on).
+func (p Problem) Title(title string) Problem {
+	return p.Key("title", title)
+}
+
+// Status sets HTTP error code for problem's status field.
+// Example: 404
+//
+// It is required.
+func (p Problem) Status(statusCode int) Problem {
+	shouldOverrideTitle := !p.keyExists("title")
+
+	if !shouldOverrideTitle {
+		typ, found := p["type"]
+		shouldOverrideTitle = !found || isEmptyTypeURI(typ.(string))
+	}
+
+	if shouldOverrideTitle {
+		// Set title by code.
+		p.Title(http.StatusText(statusCode))
+	}
+	return p.Key("status", statusCode)
+}
+
+// Detail sets the problem's detail field.
+// Example: "Optional details about the error...".
+func (p Problem) Detail(detail string) Problem {
+	return p.Key("detail", detail)
+}
+
+// Cause sets the problem's cause field.
+// Any chain of problems.
+func (p Problem) Cause(cause Problem) Problem {
+	if !cause.Validate() {
+		return p
+	}
+
+	return p.Key("cause", cause)
+}
+
+// Validate reports whether this Problem value is a valid problem one.
+func (p Problem) Validate() bool {
+	// A nil problem is not a valid one.
+	if p == nil {
+		return false
+	}
+
+	return p.keyExists("type") &&
+		p.keyExists("title") &&
+		p.keyExists("status")
+}
+
+// Error method completes the go error.
+// Returns the "[Status] Title" string form of this Problem.
+// If Problem is not a valid one, it returns "invalid problem".
+func (p Problem) Error() string {
+	if !p.Validate() {
+		return "invalid problem"
+	}
+
+	return fmt.Sprintf("[%d] %s", p["status"], p["title"])
+}

--- a/doc.go
+++ b/doc.go
@@ -38,7 +38,7 @@ Source code and other details for the project are available at GitHub:
 
 Current Version
 
-11.2.4
+11.2.5
 
 Installation
 

--- a/go19.go
+++ b/go19.go
@@ -48,8 +48,16 @@ type (
 	// See `NewConditionalHandler` for more.
 	// An alias for the `context/Filter`.
 	Filter = context.Filter
-	// A Map is a shortcut of the map[string]interface{}.
+	// A Map is an alias of map[string]interface{}.
 	Map = context.Map
+	// Problem Details for HTTP APIs.
+	// Pass a Problem value to `context.Problem` to
+	// write an "application/problem+json" response.
+	//
+	// Read more at: https://github.com/kataras/iris/wiki/Routing-error-handlers
+	//
+	// It is an alias of `context.Problem` type.
+	Problem = context.Problem
 
 	// Supervisor is a shortcut of the `host#Supervisor`.
 	// Used to add supervisor configurators on common Runners

--- a/iris.go
+++ b/iris.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	// Version is the current version number of the Iris Web Framework.
-	Version = "11.2.4"
+	Version = "11.2.5"
 )
 
 // HTTP status codes as registered with IANA.

--- a/iris.go
+++ b/iris.go
@@ -453,7 +453,6 @@ var (
 	//
 	// A shortcut of the `cache#Cache304`.
 	Cache304 = cache.Cache304
-
 	// CookiePath is a `CookieOption`.
 	// Use it to change the cookie's Path field.
 	//
@@ -499,6 +498,11 @@ var (
 	//
 	// A shortcut for the `context#IsErrPath`.
 	IsErrPath = context.IsErrPath
+	// NewProblem retruns a new Problem.
+	// Head over to the `Problem` type godoc for more.
+	//
+	// A shortcut for the `context#NewProblem`.
+	NewProblem = context.NewProblem
 )
 
 // Contains the enum values of the `Context.GetReferrer()` method,


### PR DESCRIPTION
- Implements: https://github.com/kataras/iris/issues/1335
- Wiki: https://github.com/kataras/iris/wiki/Routing-error-handlers#the-problem-type

Example Code:

```go
func newProductProblem(productName, detail string) iris.Problem {
    return iris.NewProblem().
        // The type URI, if relative it automatically convert to absolute.
        Type("/product-error"). 
        // The title, if empty then it gets it from the status code.
        Title("Product validation problem").
        // Any optional details.
        Detail(detail).
        // The status error code, required.
        Status(iris.StatusBadRequest).
        // Any custom key-value pair.
        Key("productName", productName)
        // Optional cause of the problem, chain of Problems.
        // .Cause(other iris.Problem)
}

func fireProblem(ctx iris.Context) {
    ctx.Problem(newProductProblem("product name", "problem error details"))
}
```

```json
{
  "type": "https://host.domain/product-error",
  "status": 400,
  "title": "Product validation problem",
  "detail": "problem error details",
  "productName": "product name"
}
```