### PR TITLE
Fixed typo in comment

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -410,7 +410,7 @@ type Context interface {
 	URLParam(name string) string
 	// URLParamTrim returns the url query parameter with trailing white spaces removed from a request.
 	URLParamTrim(name string) string
-	// URLParamTrim returns the escaped url query parameter from a request.
+	// URLParamEscape returns the escaped url query parameter from a request.
 	URLParamEscape(name string) string
 	// URLParamInt returns the url query parameter as int value from a request,
 	// returns -1 and an error if parse failed.


### PR DESCRIPTION
URLParamTrim returns the escaped... -> URLParamEscape returns the escaped...

# We'd love to see more contributions

Read how you can [contribute to the project](https://github.com/kataras/blob/master/CONTRIBUTING.md).

> Please attach an [issue](https://github.com/kataras/iris/issues) link which your PR solves otherwise your work may be rejected.