### PR TITLE
Fix bug:about the MVC package route binding

### DIFF
--- a/mvc/controller_method_parser.go
+++ b/mvc/controller_method_parser.go
@@ -51,7 +51,7 @@ func (l *methodLexer) reset(s string) {
 		}
 
 		if end > 0 && len(s) >= end {
-			words = append(words, s[start:end])
+			words = append(words, s[start:])
 		}
 	}
 

--- a/mvc/controller_test.go
+++ b/mvc/controller_test.go
@@ -409,8 +409,9 @@ func (c *testControllerRelPathFromFunc) GetSomethingByBy(string, int) {}
 func (c *testControllerRelPathFromFunc) GetSomethingNewBy(string, int)      {} // two input arguments, one By which is the latest word.
 func (c *testControllerRelPathFromFunc) GetSomethingByElseThisBy(bool, int) {} // two input arguments
 
-func (c *testControllerRelPathFromFunc) GetLocationX(){}
-func (c *testControllerRelPathFromFunc) GetLocationXBy(int){}
+func (c *testControllerRelPathFromFunc) GetLocationX()      {}
+func (c *testControllerRelPathFromFunc) GetLocationXY()     {}
+func (c *testControllerRelPathFromFunc) GetLocationZBy(int) {}
 
 func TestControllerRelPathFromFunc(t *testing.T) {
 	app := iris.New()
@@ -452,6 +453,13 @@ func TestControllerRelPathFromFunc(t *testing.T) {
 		Body().Equal("GET:/42")
 	e.GET("/anything/here").Expect().Status(iris.StatusOK).
 		Body().Equal("GET:/anything/here")
+
+	e.GET("/location/x").Expect().Status(iris.StatusOK).
+		Body().Equal("GET:/location/x")
+	e.GET("/location/x/y").Expect().Status(iris.StatusOK).
+		Body().Equal("GET:/location/x/y")
+	e.GET("/location/z/42").Expect().Status(iris.StatusOK).
+		Body().Equal("GET:/location/z/42")
 }
 
 type testControllerActivateListener struct {

--- a/mvc/controller_test.go
+++ b/mvc/controller_test.go
@@ -409,6 +409,9 @@ func (c *testControllerRelPathFromFunc) GetSomethingByBy(string, int) {}
 func (c *testControllerRelPathFromFunc) GetSomethingNewBy(string, int)      {} // two input arguments, one By which is the latest word.
 func (c *testControllerRelPathFromFunc) GetSomethingByElseThisBy(bool, int) {} // two input arguments
 
+func (c *testControllerRelPathFromFunc) GetLocationX(){}
+func (c *testControllerRelPathFromFunc) GetLocationXBy(int){}
+
 func TestControllerRelPathFromFunc(t *testing.T) {
 	app := iris.New()
 	New(app).Handle(new(testControllerRelPathFromFunc))


### PR DESCRIPTION
I found there has some little bug in the controller_method_parser.go
the bug is: if someone uses the code like this:
func (cc *HelloWorld) GetInfoXYT()
We can't create the Url that he wants.
We lost the T, our URL is: info/x/y
Cause I found the comment in this scope,
Like this:// it doesn't count the last uppercase 
And I think the author tries to append the lastest Code, but the last append is
words = append(words, s[start:end])
You know, If the string is GetInfoXYT the end index is the same as the start, so we lost the T.
I think this processing mode can not be accepted, so I try to fix this.

# We'd love to see more contributions

Read how you can [contribute to the project](https://github.com/kataras/blob/master/CONTRIBUTING.md).

> Please attach an [issue](https://github.com/kataras/iris/issues) link which your PR solves otherwise your work may be rejected.