### PR TITLE
Modify core/router/api_builder.go

### DIFF
--- a/_examples/file-server/basic/main.go
+++ b/_examples/file-server/basic/main.go
@@ -15,7 +15,8 @@ func newApp() *iris.Application {
 	// app.HandleDir("/css", "./assets/css")
 	// app.HandleDir("/js", "./assets/js")
 
-	app.HandleDir("/static", "./assets", iris.DirOptions{
+	v1 := app.Party("/v1")
+	v1.HandleDir("/static", "./assets", iris.DirOptions{
 		// Defaults to "/index.html", if request path is ending with **/*/$IndexName
 		// then it redirects to **/*(/) which another handler is handling it,
 		// that another handler, called index handler, is auto-registered by the framework
@@ -33,15 +34,15 @@ func newApp() *iris.Application {
 	})
 
 	// You can also register any index handler manually, order of registration does not matter:
-	// app.Get("/static", [...custom middleware...], func(ctx iris.Context) {
+	// v1.Get("/static", [...custom middleware...], func(ctx iris.Context) {
 	//  [...custom code...]
 	// 	ctx.ServeFile("./assets/index.html", false)
 	// })
 
-	// http://localhost:8080/static
-	// http://localhost:8080/static/css/main.css
-	// http://localhost:8080/static/js/jquery-2.1.1.js
-	// http://localhost:8080/static/favicon.ico
+	// http://localhost:8080/v1/static
+	// http://localhost:8080/v1/static/css/main.css
+	// http://localhost:8080/v1/static/js/jquery-2.1.1.js
+	// http://localhost:8080/v1/static/favicon.ico
 	return app
 }
 

--- a/_examples/file-server/basic/main_test.go
+++ b/_examples/file-server/basic/main_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/kataras/iris/v12/httptest"
 )
 
+const prefixURL = "/v1"
+
 type resource string
 
 func (r resource) contentType() string {
@@ -85,7 +87,7 @@ func TestFileServerBasic(t *testing.T) {
 		url := u.String()
 		contents := u.loadFromBase("./assets")
 
-		e.GET(url).Expect().
+		e.GET(prefixURL+url).Expect().
 			Status(httptest.StatusOK).
 			ContentType(u.contentType(), app.ConfigurationReadOnly().GetCharset()).
 			Body().Equal(contents)

--- a/core/router/api_builder.go
+++ b/core/router/api_builder.go
@@ -485,7 +485,8 @@ func (api *APIBuilder) HandleDir(requestPath, directory string, opts ...DirOptio
 			continue
 		}
 
-		routes = append(routes, api.createRoutes([]string{http.MethodGet}, s.RequestPath, h)...)
+		requestPath := s.RequestPath[strings.Index(s.RequestPath, api.relativePath)+len(api.relativePath):]
+		routes = append(routes, api.createRoutes([]string{http.MethodGet}, requestPath, h)...)
 		getRoute.StaticSites = append(getRoute.StaticSites, s)
 	}
 


### PR DESCRIPTION
When I use file-server like this
```
v1 := app.Party("/aa/bb")
v1.HandleDir(/static, "./assets", iris.DirOptions{
  IndexName: "/index.html",
  Gzip: false,
  ShowList: false,
})
```
and I request `http://localhost:8080/aa/bb/static` or `http://localhost:8080/aa/bb/cc/static/index.html`,
it will be 404 NOT FOUND.
Because the modified line will create a route `/aa/bb/aa/bb/static` which expected `/aa/bb/static`

Thanks for your consideration.

# We'd love to see more contributions

Read how you can [contribute to the project](https://github.com/kataras/blob/master/CONTRIBUTING.md).

> Please attach an [issue](https://github.com/kataras/iris/issues) link which your PR solves otherwise your work may be rejected.