### PR TITLE
Update pongo2 to version 4

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -77,9 +77,9 @@ Revision ID: ab226d925aa394ccecf01e515ea8479367e0961c
  pio                 2e3d576cc65913a     https://github.com/kataras/pio           
                      dd6106f1ce02837                                              
                      2c7e6d943c                                                   
- pongo2              5abacdfa4915f8a     https://github.com/flosch/pongo2   
-                     fb6de6231455488                                              
-                     066273bea6                                                 
+ pongo2              f946812ec8d53b7     https://github.com/flosch/pongo2   
+                     24e4daeb888c95a                                              
+                     b63c98b3c0                               
  protobuf            6c66de79d66478d     https://github.com/golang/protobuf       
                      166c7ea05f5d2cc                                              
                      af016fbd6b                                                   

--- a/_examples/view/template_django_0/main.go
+++ b/_examples/view/template_django_0/main.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/kataras/iris/v12"
 	// optionally, register filters like `timesince`.
-	_ "github.com/flosch/pongo2-addons/v4"
+	_ "github.com/iris-contrib/pongo2-addons/v4"
 )
 
 var startTime = time.Now()

--- a/_examples/view/template_django_0/main.go
+++ b/_examples/view/template_django_0/main.go
@@ -4,9 +4,8 @@ import (
 	"time"
 
 	"github.com/kataras/iris/v12"
-
-	// optionally, registers filters like `timesince`.
-	_ "github.com/iris-contrib/pongo2-addons"
+	// optionally, register filters like `timesince`.
+	_ "github.com/flosch/pongo2-addons/v4"
 )
 
 var startTime = time.Now()

--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385
 	github.com/fatih/structs v1.1.0
+	github.com/flosch/pongo2/v4 v4.0.0
 	github.com/gomodule/redigo v1.8.2
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-version v1.2.1
 	github.com/iris-contrib/httpexpect/v2 v2.0.5
 	github.com/iris-contrib/jade v1.1.4
-	github.com/iris-contrib/pongo2 v0.0.1
 	github.com/iris-contrib/schema v0.0.6
 	github.com/json-iterator/go v1.1.10
 	github.com/kataras/blocks v0.0.3

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	go.etcd.io/bbolt v1.3.5
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
-	golang.org/x/sys v0.0.0-20200909081042-eff7692f9009
+	golang.org/x/sys v0.0.0-20200918174421-af09f7315aff
 	golang.org/x/text v0.3.3
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	google.golang.org/protobuf v1.25.0

--- a/view/django.go
+++ b/view/django.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/kataras/iris/v12/context"
 
-	"github.com/iris-contrib/pongo2"
+	"github.com/flosch/pongo2/v4"
 )
 
 type (


### PR DESCRIPTION
When this is fixed: https://github.com/flosch/pongo2-addons/issues/8 this PR should be merged to master.

Update: the authors are not as active there as here, so we just updated our iris-contrib/pongo2-addons with path suffix of /v4. Previous versions should work as usual.