### PR TITLE
modifiy DirList's default html format

### DIFF
--- a/core/router/fs.go
+++ b/core/router/fs.go
@@ -661,6 +661,10 @@ func DirListRich(opts ...DirListRichOptions) DirListFunc {
 		}
 
 		for _, d := range dirs {
+			if !dirOptions.ShowHidden && IsHidden(d) {
+				continue
+			}
+
 			name := toBaseName(d.Name())
 
 			upath := path.Join(ctx.Request().RequestURI, name)


### PR DESCRIPTION
1. add `DirOptions.ShowHidden` option to show hidden files  or directories or not
2. modify DirList's default html format
  - use `<div>` instead of `<pre>`
  - use `<ul>` and `<li>` for file/directory list
  - add a link to parent directory
  - display current directory
  - display file mode string

