### PR TITLE
Fix panic on macos when passing a certificate as []byte to iris.TLS()

### DIFF
--- a/core/host/supervisor.go
+++ b/core/host/supervisor.go
@@ -517,9 +517,10 @@ func (su *Supervisor) shutdownOnInterrupt(ctx context.Context) {
 // fileExists tries to report whether a local physical file of "filename" exists.
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
+
 
 	return !info.IsDir()
 }

--- a/core/host/supervisor.go
+++ b/core/host/supervisor.go
@@ -521,6 +521,5 @@ func fileExists(filename string) bool {
 		return false
 	}
 
-
 	return !info.IsDir()
 }


### PR DESCRIPTION
Resolves https://github.com/kataras/iris/issues/1804
