### PR TITLE
fix the invalid format of Context.RequestParams.Get() when the value is not string type

### DIFF
--- a/context/request_params.go
+++ b/context/request_params.go
@@ -57,7 +57,7 @@ func (r *RequestParams) Get(key string) string {
 				return v.String()
 			}
 
-			return fmt.Sprintf("%s", kv.ValueRaw)
+			return fmt.Sprintf("%v", kv.ValueRaw)
 		}
 	}
 


### PR DESCRIPTION
fix the invalid format of Context.RequestParams.Get() when the value is not string type, issue of https://github.com/kataras/iris/issues/1859
