### PR TITLE
fix the issue of accesslog closing the default writer os.Stdout by SetOutput() method

### DIFF
--- a/middleware/accesslog/accesslog.go
+++ b/middleware/accesslog/accesslog.go
@@ -498,6 +498,10 @@ func (ac *AccessLog) setOutput(reset bool, writers ...io.Writer) {
 		}
 		for _, closer := range closers {
 			if closer != nil {
+				// cannot close os.Stdout/os.Stderr
+				if closer == os.Stdout || closer == os.Stderr {
+					continue
+				}
 				closer.Close()
 			}
 		}


### PR DESCRIPTION
fix the issue of [accesslog closing the default writer os.Stdout by SetOutput() method](https://github.com/kataras/iris/issues/1862)
