### PR TITLE
Remove redundant nil check

### DIFF
--- a/context/response_recorder.go
+++ b/context/response_recorder.go
@@ -244,12 +244,10 @@ func (w *ResponseRecorder) CopyTo(res ResponseWriter) {
 		}
 
 		// append the headers
-		if w.headers != nil {
-			for k, values := range w.headers {
-				for _, v := range values {
-					if to.headers.Get(v) == "" {
-						to.headers.Add(k, v)
-					}
+		for k, values := range w.headers {
+			for _, v := range values {
+				if to.headers.Get(v) == "" {
+					to.headers.Add(k, v)
 				}
 			}
 		}

--- a/context/response_writer.go
+++ b/context/response_writer.go
@@ -319,12 +319,10 @@ func (w *responseWriter) CopyTo(to ResponseWriter) {
 	}
 
 	// append the headers
-	if w.Header() != nil {
-		for k, values := range w.Header() {
-			for _, v := range values {
-				if to.Header().Get(v) == "" {
-					to.Header().Add(k, v)
-				}
+	for k, values := range w.Header() {
+		for _, v := range values {
+			if to.Header().Get(v) == "" {
+				to.Header().Add(k, v)
 			}
 		}
 	}

--- a/view/jet.go
+++ b/view/jet.go
@@ -282,10 +282,8 @@ func (s *JetEngine) initSet() {
 		}
 
 		s.Set = jet.NewSet(s.loader, opts...)
-		if s.vars != nil {
-			for key, value := range s.vars {
-				s.Set.AddGlobal(key, value)
-			}
+		for key, value := range s.vars {
+			s.Set.AddGlobal(key, value)
 		}
 	}
 	s.mu.Unlock()


### PR DESCRIPTION
From the Go docs:

> "If the map is nil, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/Cw_wnqYzemu