### PR TITLE
Downgrade Go version requirement to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kataras/iris/v12
 
-go 1.21
+go 1.20
 
 retract [v12.0.0, v12.1.8] // Retract older versions as only latest is to be depended upon. Please update to @latest
 


### PR DESCRIPTION
As part of the upgrade to Go 1.21, the Go toolchain now requires the
`go` directive to match the maximum Go version in use in dependencies.

This leads to any transitive dependency on this library to result in a
requirement of the consuming project moving to Go 1.21.

Although in a lot of cases this may not be as problematic, it forces
consumers to migrate, which we don't need to do in this case.

This also requires we bump jwt and httpexpect dependencies, as they've
downgraded, too.


---

As discussed in https://github.com/deepmap/oapi-codegen/issues/1221 and related change in https://github.com/gofiber/fiber/pull/2614. See also https://github.com/golang/go/issues/62409

Draft until below are merged:

- https://github.com/kataras/jwt/pull/17
- https://github.com/iris-contrib/httpexpect/pull/1