### PR TITLE
delete debug output '()' statement in mvc package

### DIFF
--- a/mvc/mvc.go
+++ b/mvc/mvc.go
@@ -474,10 +474,7 @@ func logController(logger *golog.Logger, c *ControllerActivator) {
 				fmt.Fprint(printer, "  ╺ ")
 				pio.WriteRich(printer, childName, colorCode)
 
-				entries := report.Entries[1:] // the ctrl value is always the first input argument so 1:..
-				if len(entries) == 0 {
-					fmt.Print("()")
-				}
+				entries := report.Entries[1:] // the ctrl value is always the first input argument so 1:..			
 				fmt.Fprintln(printer)
 
 				// pio.WriteRich(printer, "      "+route.GetTitle(), colorCode)


### PR DESCRIPTION
# We'd love to see more contributions

Read how you can [contribute to the project](https://github.com/kataras/iris/blob/main/CONTRIBUTING.md).

> Please attach an [issue](https://github.com/kataras/iris/issues) link which your PR solves otherwise your work may be rejected.

When I upgraded the local framework iris to v12.2.5, I found a strange debugging output message "()()()()()..." in the original service. Therefore, I gradually added debugging and found that it came from the mvc package. I thought maybe I could just raise the issue directly, but it might be better to raise the PR directly (it's my first time raising it). If that were just a debugging output, it would be great to delete it directly, so I mentioned this PR directly. If it's altruistic, of course, just turn it off directly.