### PR TITLE
chore: enable caching for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
         go_version: [1.21.x]
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go_version }}
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
This PR fixes the CI warning "Restore cache failed: Dependencies file is not found in /home/runner/work/iris/iris. Supported file pattern: go.sum":

<img width="1126" alt="image" src="https://github.com/kataras/iris/assets/3228886/d065bc02-1c24-4188-b805-df7dba81bfa6">

`setup-go` action has caching. But for enabling it's needed to checkout code first.

Additionally, the PR updates `checkout` action to v4.