### PR TITLE
errgroup: remove redundant `len` check

### DIFF
--- a/core/errgroup/errgroup.go
+++ b/core/errgroup/errgroup.go
@@ -330,11 +330,9 @@ func isNotNil(err error) bool {
 			return true
 		}
 
-		if len(g.children) > 0 {
-			for _, child := range g.children {
-				if isNotNil(child) {
-					return true
-				}
+		for _, child := range g.children {
+			if isNotNil(child) {
+				return true
 			}
 		}
 


### PR DESCRIPTION
A small code refactoring.

`len(g.children) > 0` is redundant because `range` already skips empty slice.